### PR TITLE
Reset color upon exit

### DIFF
--- a/git-summary
+++ b/git-summary
@@ -254,6 +254,7 @@ max_len () {
     echo "$1" | $gawk_cmd '{ print length }' | sort -rn | head -1
 }
 
+trap "printf '$NC'" EXIT
 
 git_summary $@
 


### PR DESCRIPTION
Uses a trap for any type of exit to clean up the terminal color just in case we haven't already. Was finding that on OSX it did not clear colors.