### PR TITLE
Sort the output in sequential mode to get consistent output

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ git-summary [options] path
 * **-l**: Local summary lookup. Checks only local changes which is faster as there is no need to fetch the remote.
 * **-d**: Deep lookup. Look for any git repos within the entire current directory tree. Can be slowish for large trees.
 * **-q**: Quiet mode. Only print outdated repos.
+* **-s**: Run sequentially, do not spawn multiple parallel background jobs.
 
 ## Branch status
 Currently, `git-summary` does not list multiple branches per repo. However, for single repos [`git-branch-status`](https://github.com/bill-auger/git-branch-status) does this beautifully.

--- a/git-summary
+++ b/git-summary
@@ -284,7 +284,7 @@ list_repos () {
 
 	while IFS=  read -r -d $'\0'; do
 		git_directories+=("$REPLY")
-	done < <($find_cmd 2>/dev/null)
+	done < <($find_cmd | sort -z 2>/dev/null)
 
 	for i in ${git_directories[*]}; do
 		if [[ ! -z $i ]]; then

--- a/git-summary
+++ b/git-summary
@@ -52,6 +52,8 @@ usage() {
           -q    Print nothing for repos that are up to date. Also print
                 a final tally.
 
+          -s	Run sequentially, do not spawn multiple parallel background jobs
+
           path  Path to folder containing git repos; if omitted, the
                 current working directory is used.
 
@@ -68,12 +70,14 @@ git_summary() {
     local opt
     local deeplookup=0
     local quiet=0
-    while getopts "hldq" opt; do
+    local sequential=0
+    while getopts "hldqs" opt; do
         case "${opt}" in
             h) usage ; exit 1 ;;
             l) local_only=1 ;;    # Will skip "git fetch"
             d) deeplookup=1 ;;
             q) quiet=1 ;;
+	    s) sequential=1 ;;    # run sequentially
         esac
     done
     shift $((OPTIND-1))
@@ -104,7 +108,11 @@ git_summary() {
 
     local f
     for f in $repos ; do
-        summarize_one_git_repo $f "$template" "$local_only" "$quiet" >&1 &
+	if [ $sequential -eq 0 ] ; then
+	    summarize_one_git_repo $f "$template" "$local_only" "$quiet" >&1 &  # multiple bg jobs
+	else
+	    summarize_one_git_repo $f "$template" "$local_only" "$quiet" >&1    # sequentially
+	fi
         (( repo_count+=1 ))
     done
     wait

--- a/git-summary
+++ b/git-summary
@@ -77,7 +77,7 @@ git_summary() {
             l) local_only=1 ;;    # Will skip "git fetch"
             d) deeplookup=1 ;;
             q) quiet=1 ;;
-	    s) sequential=1 ;;    # run sequentially
+            s) sequential=1 ;;    # run sequentially
         esac
     done
     shift $((OPTIND-1))
@@ -108,11 +108,11 @@ git_summary() {
 
     local f
     for f in $repos ; do
-	if [ $sequential -eq 0 ] ; then
-	    summarize_one_git_repo $f "$template" "$local_only" "$quiet" >&1 &  # multiple bg jobs
-	else
-	    summarize_one_git_repo $f "$template" "$local_only" "$quiet" >&1    # sequentially
-	fi
+        if [ $sequential -eq 0 ] ; then
+            summarize_one_git_repo $f "$template" "$local_only" "$quiet" >&1 &  # multiple bg jobs
+        else
+            summarize_one_git_repo $f "$template" "$local_only" "$quiet" >&1    # sequentially
+        fi
         (( repo_count+=1 ))
     done
     wait


### PR DESCRIPTION
I have used the sequential mode from @tobiasw1 I hope he does not mind?

And then I sort the `find` output.

So now if we use `-ls` options, the output is sorted (in sequential mode, the local mode is also highly recommended).
It does not work in parallel mode, I did not find an easy way to to print the parallel output sorted.