### PR TITLE
feat: add alpine container support in Google Cloud Platform, Container Optimised OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,17 @@ git-summary is a bash script that will neatly list the current status of any git
 <img src="screenshot.png" width="60%">
 
 ## Requirements
-**Currently supported operating systems:** Linux, MacOS and Cygwin
+**Currently supported operating systems:** Linux, MacOS and Cygwin, containers (alpine based) on Google Cloud Platform - Container Optimised OS (Chromium OS)
 
 ### Linux
 * `sudo apt-get install gawk`
 
 ### MacOS
 * `brew install coreutils`
+
+### in Container on Google Cloud Platform - Container Optimised OS (alpine based containers)
+xargs in Chromium OS does not support -L option, findutils puts an xargs with support for -L
+* `apk add gawk, findutils`
 
 ## Installation
 ### Via aliasing

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ git-summary is a bash script that will neatly list the current status of any git
 
 ### in Container on Google Cloud Platform - Container Optimised OS (alpine based containers)
 xargs in Chromium OS does not support -L option, findutils puts an xargs with support for -L
-* `apk add gawk, findutils`
+* `apk add gawk findutils`
 
 ## Installation
 ### Via aliasing

--- a/git-summary
+++ b/git-summary
@@ -131,10 +131,17 @@ detect_OS() {
     dirname_cmd="gdirname"
     gawk_cmd="awk"
   elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then  # Linux
-    OS=Linux
-    readlink_cmd="readlink"
-    dirname_cmd="dirname"
-    gawk_cmd="gawk"
+    if [[ $(cat /proc/version) == *"Chromium OS"* ]]; then
+      OS=Linux
+      readlink_cmd="readlink"
+      dirname_cmd="dirname_zero"
+      gawk_cmd="gawk"
+    else
+      OS=Linux
+      readlink_cmd="readlink"
+      dirname_cmd="dirname"
+      gawk_cmd="gawk"
+    fi
   elif [ "$(expr substr $(uname -s) 1 6)" == "CYGWIN" ]; then  # Cygwin
     OS=CYGWIN
     readlink_cmd="readlink"
@@ -147,6 +154,11 @@ detect_OS() {
 }
 
 GIT4WINDOWS=1
+
+#  `dirname -z` does not exist on  Chromium OS (Google Cloud Platform - Container Optimised OS)
+dirname_zero(){
+    printf '%b' $(dirname $2)'\0'
+}
 
 detect_Git4Windows() {
     if [[ "$OS" == "CYGWIN" && "$(git --version)" == *"windows"* ]]; then


### PR DESCRIPTION
It appears that Chromium OS on which the Google Cloud Platform - Container Optimised OS is based does not have support for the `-z` option in  `dirname`. additionally `xargs -L` is also unsupported. 

THis is fixable with the `dirname_zero` function in the git-summary and detection of OS variant, additionally to installing `gawk` if `findutils` is installed it installs an `xargs` with support for the option `-L`
