### PR TITLE
Add a manual page

### DIFF
--- a/git-summary.1
+++ b/git-summary.1
@@ -1,0 +1,50 @@
+.TH GIT-SUMMARY 1 2023-04-13 git-summary ""
+.SH NAME
+GIT-SUMMARY - summarize the status of a collection of Git repositories
+.SH SYNOPSIS
+.B git-summary [-h] [-d] [-l] [-q] [-s] [path]
+.SH DESCRIPTION
+.P
+git-summary displays a table on the terminal summarizing the status of multiple
+Git repositories.
+If the given path is within a Git repository, then only information for that
+repository is shown.
+Otherwise (the path is not in a Git repository), subdirectories of this
+directory that are Git repositories are chosen.
+The default path if none is given is the current directory.
+.P
+Before displaying any information on a repository,
+.B git fetch
+is run to update remote information.
+.P
+Displayed information includes:
+.P
+- The repository location on disk.
+.br
+- The current branch name.
+.br
+- Presence of uncommitted changes.
+.br
+- Presence of untracked files.
+.br
+- Presence of unpushed and unpulled changes, if the current branch is tracking
+an upstream branch.
+.SH OPTIONS
+.TP
+-h
+Display a help message showing how to use the program.
+.TP
+-d
+Deep lookup, search the full directory tree for Git repositories.
+By default, only subdirectories immediately below the given one are checked.
+.TP
+-l
+Local operation only, do not fetch.
+.TP
+-q
+Quiet mode, only print outdated repositories.
+.TP
+-s
+Sorted output, display repositories in sorted order.
+By default, repositories are checked in parallel and may appear in any order.
+This mode slows down operation as it serializes fetching of remotes.


### PR DESCRIPTION
Hi there, and thanks @MirkoLedda, Adham, and the other authors for this useful tool.  It saves me a bunch of time.

Would you be interested in having a man page for it?  This is something I put together quickly.  I keep Debian and Gentoo packages for git-summary in my unofficial repos and since Debian policy requires man pages for all commands, I figured why not write one.  I'm currently shipping it separately, but I'd be happy for it to get included upstream.

Documentation on writing man pages is (naturally) in man pages `man-pages(7)`, `man(7)`, and `groff(7)`.  Most if not all of the macros used should be described there.

For completeness: I submit this under the same MIT license as this repo.

Cheers,
Bryan