### PR TITLE
Fix ugly error when upstream is gone

### DIFF
--- a/git-summary
+++ b/git-summary
@@ -250,8 +250,7 @@ summarize_one_git_repo () {
 
     ### Check remote state
     local rstate=""
-    local has_upstream=`gitC $f rev-parse --abbrev-ref @{u} 2> /dev/null | wc -l`
-    if [ $has_upstream -ne 0 ] ; then
+    if $(gitC $f rev-parse --verify --quiet --abbrev-ref @{u} > /dev/null); then
         if [ $local_only -eq 0 ] ; then
             gitC $f fetch -q &> /dev/null
         fi


### PR DESCRIPTION
If the output of git status gives you:

```
On branch XYZ
Your branch is based on 'origin/XYZ', but the upstream is gone.
  (use "git branch --unset-upstream" to fixup)

nothing to commit, working tree clean
```

then git summary will give you an ugly error message and nothing in the State columns

```
Repository  Branch    State
==========  ========  =====
fatal: no such branch: '..'
fatal: ambiguous argument '@{u}..': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
.           XYZ       
```

This commit tries to fix that by using "--verify --quiet" and the exit code of git rev-parse.